### PR TITLE
Update for Nim 1.2; better midi support & example

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,2 @@
+catjackmidi: catjackmidi.nim
+	nim c --gc:arc catjackmidi.nim

--- a/examples/catjackmidi.nim
+++ b/examples/catjackmidi.nim
@@ -1,0 +1,77 @@
+#
+# This example registers a new jack client with 8 midi_in ports
+# and then for each input message, prints the midi message as both
+# hex & seq[uint8]'s representation.
+#
+# Contributed by Robert Thomson
+#
+# MIT license, etc
+#
+
+import os
+import jack
+import strutils
+
+var client: PJackClient
+var event: JackMidiEvent
+var midi_ports: seq[PJackPort]
+
+proc echo(event: var JackMidiEvent, portnum: int=0) =
+  var s = newSeq[uint8](event.size)
+  copyMem(s[0].addr, event.buffer, event.size)
+  stdout.write($portnum)
+  stdout.write(": ")
+  for i in s:
+    stdout.write(toHex(i))
+    stdout.write(" ")
+  stdout.write("/ ")
+  stdout.write($s)
+  stdout.write("\n")
+  stdout.flushFile()
+
+proc process_cb*(nframes: JackNFrames, arg: pointer): int {.cdecl.} =
+  var portnum = 0
+  for port in midi_ports:
+    portnum += 1
+    let inbuf = jack_port_get_buffer(port, nframes)
+    let count = jack_midi_get_event_count(inbuf)
+    var res: int
+
+    for i in 0..<count:
+      res = jack_midi_event_get(event.addr, inbuf, i)
+      if res == 0:
+        echo(event, portnum)
+
+proc main() =
+  var status: JackStatus
+  var options: Jack_options
+  client = jack_client_open("catjackmidi", options, status.addr)
+  if status != 0:
+    quit "Failed to create jack client"
+
+  var p1 = jack_port_register(client, "midi_in_1", JACK_DEFAULT_MIDI_TYPE, (uint64)JackPortIsInput, 0)
+  var p2 = jack_port_register(client, "midi_in_2", JACK_DEFAULT_MIDI_TYPE, (uint64)JackPortIsInput, 0)
+  var p3 = jack_port_register(client, "midi_in_3", JACK_DEFAULT_MIDI_TYPE, (uint64)JackPortIsInput, 0)
+  var p4 = jack_port_register(client, "midi_in_4", JACK_DEFAULT_MIDI_TYPE, (uint64)JackPortIsInput, 0)
+  var p5 = jack_port_register(client, "midi_in_5", JACK_DEFAULT_MIDI_TYPE, (uint64)JackPortIsInput, 0)
+  var p6 = jack_port_register(client, "midi_in_6", JACK_DEFAULT_MIDI_TYPE, (uint64)JackPortIsInput, 0)
+  var p7 = jack_port_register(client, "midi_in_7", JACK_DEFAULT_MIDI_TYPE, (uint64)JackPortIsInput, 0)
+  var p8 = jack_port_register(client, "midi_in_8", JACK_DEFAULT_MIDI_TYPE, (uint64)JackPortIsInput, 0)
+  midi_ports = @[p1, p2, p3, p4, p5, p6, p7, p8]
+
+  status = jack_set_process_callback(client, JackProcessCallback(process_cb), nil)
+  if status != 0:
+    quit "Failed to configure process callback"
+
+  status = jack_activate(client)
+  if status != 0:
+    quit "Failed to activate client"
+
+  try:
+    while true:
+      sleep(60000)
+  finally:
+    discard jack_client_close(client)
+
+when isMainModule:
+  main()

--- a/jack.nim
+++ b/jack.nim
@@ -9,6 +9,7 @@
 
 const
    jackh = "<jack/jack.h>"
+   jackmidiporth = "<jack/midiport.h>"
 
    JACK_DEFAULT_AUDIO_TYPE* = "32 bit float mono audio"
    JACK_DEFAULT_MIDI_TYPE* = "8 bit raw midi"
@@ -69,7 +70,7 @@ type
        min, max: Jack_nframes
 
    JackLatencyCallback* = proc(mode: Jack_latency_callback_mode, arg: pointer)
-   JackProcessCallback* = proc(nframes: Jack_nframes, arg: pointer): int
+   JackProcessCallback* = proc(nframes: Jack_nframes, arg: pointer): int {.cdecl.}
    JackThreadCallback* = proc(arg: pointer)
    JackThreadInitCallback* = proc(arg: pointer)
    JackGraphOrderCallback* = proc(arg: pointer): int 
@@ -143,17 +144,21 @@ type
 
    Jack_ringbuffer_data {.importc: "jack_ringbuffer_t", header: jackh.} = object
       buf: ptr char
-      len: csize
+      len: csize_t
 
    Jack_ringbuffer {.importc: "jack_ringbuffer_t", header: jackh.} = object
       buf: ptr char
-      write_ptr, read_ptr, size, size_mask: csize
+      write_ptr, read_ptr, size, size_mask: csize_t
       mlocked: int
 
    #TODO
    #Jack_thread_creator {.importc: "jack_thread_creator_t", header: jackh.} = proc(jack_native_thread_t *, pthread_attr_t *, void *(*function)(void *), void *arg): int
 
-   JackMidiEvent {.importc: "jack_midi_event_t", header: jackh.} = distinct pointer
+   JackMidiEvent* {.importc: "jack_midi_event_t", header: jackmidiporth.} = object
+     time*: Jack_nframes
+     size*: csize_t
+     buffer*: ptr JackMidiData
+
    JackMidiData* = uint8
 
    JackSessionEventType* {.importc.} = enum
@@ -292,7 +297,7 @@ proc jack_disconnect*(client: PJackClient,  source_port: cstring, destination_po
 proc jack_port_disconnect*(client: PJackClient, port: PJackPort): int {.importc: "jack_port_disconnect", header: jackh.}
 proc jack_port_name_size*(): int {.importc: "jack_port_name_size", header: jackh.}
 proc jack_port_type_size*(): int {.importc: "jack_port_type_size", header: jackh.}
-proc jack_port_type_get_buffer_size*(client: PJackClient, port_type: cstring): csize {.importc: "jack_port_type_get_buffer_size", header: jackh.}
+proc jack_port_type_get_buffer_size*(client: PJackClient, port_type: cstring): csize_t {.importc: "jack_port_type_get_buffer_size", header: jackh.}
 
 # Managing and determining latency
 
@@ -338,19 +343,19 @@ proc jack_internal_client_unload *(client: PJackClient, intclient: Jack_intclien
 
 # Ring Buffer
 
-proc jack_ringbuffer_create*(sz: csize): ptr Jack_ringbuffer {.importc: "jack_ringbuffer_create", header: jackh.}
+proc jack_ringbuffer_create*(sz: csize_t): ptr Jack_ringbuffer {.importc: "jack_ringbuffer_create", header: jackh.}
 proc jack_ringbuffer_free*(rb: Jack_ringbuffer) {.importc: "jack_ringbuffer_free", header: jackh.}
 proc jack_ringbuffer_get_read_vector*(rb: Jack_ringbuffer, vec: ptr Jack_ringbuffer_data) {.importc: "jack_ringbuffer_get_read_vector", header: jackh.}
 proc jack_ringbuffer_get_write_vector*(rb: Jack_ringbuffer, vec: ptr Jack_ringbuffer_data) {.importc: "jack_ringbuffer_get_write_vector", header: jackh.}
-proc jack_ringbuffer_read*(rb: Jack_ringbuffer, dest: cstring, cnt: csize): csize {.importc: "jack_ringbuffer_read", header: jackh.}
-proc jack_ringbuffer_peek*(rb: Jack_ringbuffer, dest: cstring, cnt: csize): csize {.importc: "jack_ringbuffer_peek", header: jackh.}
-proc jack_ringbuffer_read_advance*(rb: Jack_ringbuffer, cnt: csize) {.importc: "jack_ringbuffer_read_advance", header: jackh.}
-proc jack_ringbuffer_read_space*(rb: Jack_ringbuffer): csize {.importc: "jack_ringbuffer_read_space", header: jackh.}
+proc jack_ringbuffer_read*(rb: Jack_ringbuffer, dest: cstring, cnt: csize_t): csize_t {.importc: "jack_ringbuffer_read", header: jackh.}
+proc jack_ringbuffer_peek*(rb: Jack_ringbuffer, dest: cstring, cnt: csize_t): csize_t {.importc: "jack_ringbuffer_peek", header: jackh.}
+proc jack_ringbuffer_read_advance*(rb: Jack_ringbuffer, cnt: csize_t) {.importc: "jack_ringbuffer_read_advance", header: jackh.}
+proc jack_ringbuffer_read_space*(rb: Jack_ringbuffer): csize_t {.importc: "jack_ringbuffer_read_space", header: jackh.}
 proc jack_ringbuffer_mlock*(rb: Jack_ringbuffer): int {.importc: "jack_ringbuffer_mlock", header: jackh.}
 proc jack_ringbuffer_reset*(rb: Jack_ringbuffer) {.importc: "jack_ringbuffer_reset", header: jackh.}
-proc jack_ringbuffer_write*(rb: Jack_ringbuffer, src: cstring, cnt: csize): csize {.importc: "jack_ringbuffer_write", header: jackh.}
-proc jack_ringbuffer_write_advance*(rb: Jack_ringbuffer, cnt: csize) {.importc: "jack_ringbuffer_write_advance", header: jackh.}
-proc jack_ringbuffer_write_space*(rb: Jack_ringbuffer): csize {.importc: "jack_ringbuffer_write_space", header: jackh.}
+proc jack_ringbuffer_write*(rb: Jack_ringbuffer, src: cstring, cnt: csize_t): csize_t {.importc: "jack_ringbuffer_write", header: jackh.}
+proc jack_ringbuffer_write_advance*(rb: Jack_ringbuffer, cnt: csize_t) {.importc: "jack_ringbuffer_write_advance", header: jackh.}
+proc jack_ringbuffer_write_space*(rb: Jack_ringbuffer): csize_t {.importc: "jack_ringbuffer_write_space", header: jackh.}
 
 # Transport
 
@@ -381,11 +386,11 @@ proc jack_drop_real_time_scheduling *(thread: Jack_native_thread): int {.importc
 # Reading and writing MIDI data
 
 proc jack_midi_get_event_count*(port_buffer: pointer): Jack_nframes {.importc: "jack_midi_get_event_count", header: jackh.}
-proc jack_midi_event_get*(event: Jack_midi_event, port_buffer: pointer, event_index: uint32): int {.importc: "jack_midi_event_get ", header: jackh.}
+proc jack_midi_event_get*(event: ptr Jack_midi_event, port_buffer: pointer, event_index: uint32): int {.importc: "jack_midi_event_get ", header: jackh.}
 proc jack_midi_clear_buffer*(port_buffer: pointer) {.importc: "jack_midi_clear_buffer ", header: jackh.}
-proc jack_midi_max_event_size*(port_buffer: pointer): csize {.importc: "jack_midi_max_event_size ", header: jackh.}
-proc jack_midi_event_reserve*(port_buffer: pointer, time: Jack_nframes, data_size: csize): ptr JackMidiData {.importc: "jack_midi_event_reserve ", header: jackh.}
-proc jack_midi_event_write*(port_buffer: pointer, time: Jack_nframes, data: ptr Jack_midi_data, data_size: csize): int {.importc: "jack_midi_event_write ", header: jackh.}
+proc jack_midi_max_event_size*(port_buffer: pointer): csize_t {.importc: "jack_midi_max_event_size ", header: jackh.}
+proc jack_midi_event_reserve*(port_buffer: pointer, time: Jack_nframes, data_size: csize_t): ptr JackMidiData {.importc: "jack_midi_event_reserve ", header: jackh.}
+proc jack_midi_event_write*(port_buffer: pointer, time: Jack_nframes, data: ptr Jack_midi_data, data_size: csize_t): int {.importc: "jack_midi_event_write ", header: jackh.}
 proc jack_midi_get_lost_event_count*(port_buffer: pointer): uint32 {.importc: "jack_midi_get_lost_event_count ", header: jackh.}
 
 # Sessions


### PR DESCRIPTION
* update binding to use csize_t (nim 1.2 has deprecated csize)
* turn JackMidiEvent into an object with fields
* add examples/catjackmidi.nim & a Makefile